### PR TITLE
Initialize errorMessages in DataHandler

### DIFF
--- a/Classes/DataHandler/AbstractDataHandler.php
+++ b/Classes/DataHandler/AbstractDataHandler.php
@@ -18,7 +18,7 @@ abstract class AbstractDataHandler implements DataHandlerInterface, SingletonInt
     /**
      * @var array
      */
-    protected $errorMessages;
+    protected $errorMessages = [];
 
     /**
      * Return error that have occurred while processing the data.


### PR DESCRIPTION
While using EXT:media I stumbled upon an issue while deleting one or more images. The problem was, that `\Fab\Vidi\Domain\Repository\ContentRepository->getErrorMessages()` should return an array but the `errorMessages` variable was never initialized.